### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ When the reader has completed this Code Pattern, they will understand how to:
 
 *This Code Pattern was built with the PowerAI Vision Technology Preview v3.0.*
 
-Go to [Try Power AI](https://developer.ibm.com/linuxonpower/deep-learning-powerai/try-powerai/) 
+Go to [Try Power AI](https://developer.ibm.com/linuxonpower/deep-learning-powerai/try-powerai/)
 and use `On Premise` to download an installer to deploy the preview on
 your Power Systems, or use `SuperVessel` and register for access to the
 SuperVessel cloud where you can try the preview.
@@ -60,9 +60,6 @@ SuperVessel cloud where you can try the preview.
 
 # Steps
 
-<!-- TODO: Update the repo and tracking id -->
-<!-- TODO: Will be used if we have an example app to deploy -->
-<!--
 Use the ``Deploy to IBM Cloud`` button **OR** run locally.
 
 ## Deploy to IBM Cloud

--- a/app.js
+++ b/app.js
@@ -20,8 +20,6 @@
 const express = require('express');
 const request = require('request');
 
-require('metrics-tracker-client').track();
-
 require('dotenv').config({
   silent: true,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1687,16 +1687,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "metrics-tracker-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/metrics-tracker-client/-/metrics-tracker-client-0.2.3.tgz",
-      "integrity": "sha512-AtTxMSz4ypCpUBmu8lhnJ609TSFenKUgIdbsopac7l6/TFsKQZGB9W8D7yXLzeVvev0LKrqWzLHtH0XTeUcxeQ==",
-      "requires": {
-        "cwd": "0.10.0",
-        "js-yaml": "3.10.0",
-        "restler": "3.4.0"
-      }
-    },
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "dotenv": "^4.0.0",
     "express": "4.16.2",
-    "metrics-tracker-client": "^0.2.3",
     "request": "2.83.0"
   },
   "engines": {


### PR DESCRIPTION
Remove:
Badge at top of README
use of metric tracker in app:
i.e. `require('metrics-tracker-client').track();`
package.json for metrics-tracker
package-lock.json stuff